### PR TITLE
phase-3.0: add distilbart-cnn-6-6-q8 and t5-small-q8 placeholders to …

### DIFF
--- a/daily-planner/lib/ai/llm/config.ts
+++ b/daily-planner/lib/ai/llm/config.ts
@@ -18,6 +18,30 @@ export const JSON_INSTRUCTIONS = `You are to output ONLY valid JSON that matches
 
 /* Replace URLs + hashes with your artifacts. Use https with range support for resumable downloads. */
 export const MODEL_REGISTRY: Record<ModelId, ModelSpec> = {
+  /* --- Phase 3.0: new placeholders (no behavior change; URLs/hashes REQUIRED) --- */
+  'distilbart-cnn-6-6-q8': {
+    id: 'distilbart-cnn-6-6-q8',
+    displayName: 'DistilBART-CNN 6-6 (INT8)',
+    sourceURL: 'REQUIRED',         // REQUIRED: CDN https URL to .onnx (supports range)
+    sha256: 'REQUIRED',            // REQUIRED: SHA-256 of the ONNX file
+    sizeMB: 150,
+    maxInputTokens: 1024,
+    maxOutputTokens: 256,
+    quantization: 'int8',
+    tokenizer: 'roberta-bpe',      // DistilBART/BART family uses Roberta/BPE
+  },
+  't5-small-q8': {
+    id: 't5-small-q8',
+    displayName: 'T5-small (INT8)',
+    sourceURL: 'REQUIRED',         // REQUIRED: CDN https URL to .onnx (supports range)
+    sha256: 'REQUIRED',            // REQUIRED: SHA-256 of the ONNX file
+    sizeMB: 120,
+    maxInputTokens: 512,
+    maxOutputTokens: 256,
+    quantization: 'int8',
+    tokenizer: 't5-spm',           // T5 uses SentencePiece
+  },
+
   'tiny-sum-onnx': {
     id: 'tiny-sum-onnx',
     displayName: 'Tiny Summarizer (ONNX int8)',

--- a/daily-planner/lib/ai/llm/types.ts
+++ b/daily-planner/lib/ai/llm/types.ts
@@ -1,9 +1,14 @@
 // daily-planner/lib/ai/llm/types.ts
 export type SummaryType = 'weekly' | 'monthly' | 'yearly';
 
-export type ModelId = 'tiny-sum-onnx' | 'base-sum-onnx' | 'pro-sum-onnx';
+export type ModelId =
+  | 'tiny-sum-onnx'
+  | 'base-sum-onnx'
+  | 'pro-sum-onnx'
+  | 'distilbart-cnn-6-6-q8'
+  | 't5-small-q8';
 
-export interface ModelSpec {
+  export interface ModelSpec {
   id: ModelId;
   displayName: string;
   sourceURL: string;
@@ -12,8 +17,8 @@ export interface ModelSpec {
   maxInputTokens: number;
   maxOutputTokens: number;
   quantization?: 'int4' | 'int8' | 'fp16' | 'fp32';
-  tokenizer?: 'gpt2-bpe' | 'llama-bpe' | 'custom';
-}
+  tokenizer?: 'gpt2-bpe' | 'llama-bpe' | 'roberta-bpe' | 't5-spm' | 'custom';
+  }
 
 export interface DeviceProfile {
   os: 'ios' | 'android' | 'windows' | 'macos' | 'web';


### PR DESCRIPTION
…MODEL_REGISTRY

- Extended ModelId type and tokenizer enum to include new models
- Added MODEL_REGISTRY entries for distilbart-cnn-6-6-q8 and t5-small-q8 with size, token limits, quantization, and tokenizer family
- Marked sourceURL and sha256 as REQUIRED placeholders to prevent accidental use
- No behavior changes; default selection and existing models unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added two new lightweight model options: distilbart-cnn-6-6-q8 and t5-small-q8 (int8), enabling broader on-device summarization choices.
  - Expanded tokenizer compatibility to include Roberta-BPE and T5 SentencePiece, improving model interoperability.

- Chores
  - Introduced an optional checksum field in model definitions to support resource verification.
  - Updated supported model identifiers to include the new models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->